### PR TITLE
TICKET-102 | completed

### DIFF
--- a/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
+++ b/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
@@ -1,5 +1,7 @@
 package ee.taltech.inbankbackend.config;
 
+import java.time.Period;
+
 /**
  * Holds all necessary constants for the decision engine.
  */
@@ -11,4 +13,8 @@ public class DecisionEngineConstants {
     public static final int SEGMENT_1_CREDIT_MODIFIER = 100;
     public static final int SEGMENT_2_CREDIT_MODIFIER = 300;
     public static final int SEGMENT_3_CREDIT_MODIFIER = 1000;
+
+    public static final Period ESTONIA_LIFE_EXPECTANCY = Period.of(76, 7, 12);
+    public static final Period LATVIA_LIFE_EXPECTANCY = Period.of(74, 3, 9);
+    public static final Period LITHUANIA_LIFE_EXPECTANCY = Period.of(72, 5, 22);
 }

--- a/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
+++ b/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
@@ -1,9 +1,6 @@
 package ee.taltech.inbankbackend.endpoint;
 
-import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
-import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
-import ee.taltech.inbankbackend.exceptions.NoValidLoanException;
+import ee.taltech.inbankbackend.exceptions.*;
 import ee.taltech.inbankbackend.service.Decision;
 import ee.taltech.inbankbackend.service.DecisionEngine;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +51,7 @@ public class DecisionEngineController {
             response.setErrorMessage(e.getMessage());
 
             return ResponseEntity.badRequest().body(response);
-        } catch (NoValidLoanException e) {
+        } catch (NoValidLoanException | InvalidAgeException e ) {
             response.setLoanAmount(null);
             response.setLoanPeriod(null);
             response.setErrorMessage(e.getMessage());

--- a/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidAgeException.java
+++ b/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidAgeException.java
@@ -1,0 +1,28 @@
+package ee.taltech.inbankbackend.exceptions;
+
+/**
+ * Thrown when the age is not valid according to restrictions.
+ */
+public class InvalidAgeException extends Throwable {
+    private final String message;
+    private final Throwable cause;
+
+    public InvalidAgeException(String message) {
+        this(message, null);
+    }
+
+    public InvalidAgeException(String message, Throwable cause) {
+        this.message = message;
+        this.cause = cause;
+    }
+
+    @Override
+    public Throwable getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/java/ee/taltech/inbankbackend/endpoint/DecisionEngineControllerTest.java
+++ b/src/test/java/ee/taltech/inbankbackend/endpoint/DecisionEngineControllerTest.java
@@ -1,10 +1,7 @@
 package ee.taltech.inbankbackend.endpoint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
-import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
-import ee.taltech.inbankbackend.exceptions.NoValidLoanException;
+import ee.taltech.inbankbackend.exceptions.*;
 import ee.taltech.inbankbackend.service.Decision;
 import ee.taltech.inbankbackend.service.DecisionEngine;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +51,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenValidRequest_whenRequestDecision_thenReturnsExpectedResponse()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         Decision decision = new Decision(1000, 12, null);
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt())).thenReturn(decision);
 
@@ -83,7 +80,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenInvalidPersonalCode_whenRequestDecision_thenReturnsBadRequest()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt()))
                 .thenThrow(new InvalidPersonalCodeException("Invalid personal code"));
 
@@ -112,7 +109,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenInvalidLoanAmount_whenRequestDecision_thenReturnsBadRequest()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt()))
                 .thenThrow(new InvalidLoanAmountException("Invalid loan amount"));
 
@@ -141,7 +138,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenInvalidLoanPeriod_whenRequestDecision_thenReturnsBadRequest()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt()))
                 .thenThrow(new InvalidLoanPeriodException("Invalid loan period"));
 
@@ -170,7 +167,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenNoValidLoan_whenRequestDecision_thenReturnsBadRequest()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt()))
                 .thenThrow(new NoValidLoanException("No valid loan available"));
 
@@ -199,7 +196,7 @@ public class DecisionEngineControllerTest {
     @Test
     public void givenUnexpectedError_whenRequestDecision_thenReturnsInternalServerError()
             throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
+            InvalidLoanAmountException, InvalidAgeException {
         when(decisionEngine.calculateApprovedLoan(anyString(), anyInt(), anyInt())).thenThrow(new RuntimeException());
 
         DecisionRequest request = new DecisionRequest("1234", 10, 10);

--- a/src/test/java/ee/taltech/inbankbackend/service/DecisionEngineTest.java
+++ b/src/test/java/ee/taltech/inbankbackend/service/DecisionEngineTest.java
@@ -1,10 +1,7 @@
 package ee.taltech.inbankbackend.service;
 
 import ee.taltech.inbankbackend.config.DecisionEngineConstants;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanAmountException;
-import ee.taltech.inbankbackend.exceptions.InvalidLoanPeriodException;
-import ee.taltech.inbankbackend.exceptions.InvalidPersonalCodeException;
-import ee.taltech.inbankbackend.exceptions.NoValidLoanException;
+import ee.taltech.inbankbackend.exceptions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +38,7 @@ class DecisionEngineTest {
 
     @Test
     void testSegment1PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-            InvalidPersonalCodeException, InvalidLoanAmountException {
+            InvalidPersonalCodeException, InvalidLoanAmountException, InvalidAgeException {
         Decision decision = decisionEngine.calculateApprovedLoan(segment1PersonalCode, 4000, 12);
         assertEquals(4200, decision.getLoanAmount());
         assertEquals(42, decision.getLoanPeriod());
@@ -49,18 +46,20 @@ class DecisionEngineTest {
 
     @Test
     void testSegment2PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-            InvalidPersonalCodeException, InvalidLoanAmountException {
+            InvalidPersonalCodeException, InvalidLoanAmountException, InvalidAgeException {
         Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 4000, 12);
         assertEquals(5400, decision.getLoanAmount());
         assertEquals(18, decision.getLoanPeriod());
     }
 
     @Test
-    void testSegment3PersonalCode() throws InvalidLoanPeriodException, NoValidLoanException,
-            InvalidPersonalCodeException, InvalidLoanAmountException {
-        Decision decision = decisionEngine.calculateApprovedLoan(segment3PersonalCode, 4000, 12);
-        assertEquals(10000, decision.getLoanAmount());
-        assertEquals(12, decision.getLoanPeriod());
+    void testPersonalCodeTooOld() throws InvalidLoanPeriodException, NoValidLoanException,
+            InvalidPersonalCodeException, InvalidLoanAmountException, InvalidAgeException {
+        try {
+            Decision decision = decisionEngine.calculateApprovedLoan(segment3PersonalCode, 4000, 12);
+        } catch (InvalidAgeException e) {
+            // Expected exception thrown
+        }
     }
 
     @Test
@@ -96,7 +95,7 @@ class DecisionEngineTest {
 
     @Test
     void testFindSuitableLoanPeriod() throws InvalidLoanPeriodException, NoValidLoanException,
-            InvalidPersonalCodeException, InvalidLoanAmountException {
+            InvalidPersonalCodeException, InvalidLoanAmountException, InvalidAgeException {
         Decision decision = decisionEngine.calculateApprovedLoan(segment2PersonalCode, 2000, 12);
         assertEquals(3600, decision.getLoanAmount());
         assertEquals(12, decision.getLoanPeriod());


### PR DESCRIPTION
# Added age-related restrictions to loan applications.

Age validation takes place in the input verification phase and throws an exception when age is not valid. Exception is handled by the DecisionEngineController. Made a separate method validateAge which holds the logic of the restrictions. 

## Restrictions: 
- Client can not be underage (under 18 years old);
- Client's  expected lifespan needs to be longer than our maximum loan period;

## Code
```java
private void validateAge(String personalCode) throws InvalidAgeException, PersonalCodeException {

        // Verify age
        Period age = parser.getAge(personalCode);

        if (age.getYears() < 18) {
            throw new InvalidAgeException("You must be of legal age to apply for a loan!");
        }

        // Get personal data
        LocalDate dateOfBirth = parser.getDateOfBirth(personalCode);
        Period lifeExpectancy = getLifeExpectancy(getCountry(personalCode));

        //
        LocalDate expectedDateOfDeath = dateOfBirth.plus(lifeExpectancy);
        LocalDate dateNow = LocalDate.now();

        // Expected period alive must be more than 60 months (5 years)
        Period expectedPeriodAlive = Period.between(dateNow, expectedDateOfDeath);

        if (expectedPeriodAlive.getYears() < 5) {
            throw new InvalidAgeException("Loan application age limit exceeded!");
        }
    }
```